### PR TITLE
Fix python try-except example to catch TypeError

### DIFF
--- a/chapters/python.adoc
+++ b/chapters/python.adoc
@@ -715,9 +715,9 @@ more specific, you can catch specific errors in the following manner:
 num1 = 8
 
 print("Input the number that will divide:")
-num2 = int(input())
 
 try:
+    num2 = int(input())
     result = num1 / num2
     print(result)
 except ZeroDivisionError:


### PR DESCRIPTION
int(input()) needs to be moved inside the try block to catch TypeError from a non-integer input