### PR TITLE
Fix typo in 9.4.1

### DIFF
--- a/chapters/binary.adoc
+++ b/chapters/binary.adoc
@@ -268,7 +268,7 @@ Starting program: /home/samuel/Desktop/problems/vuln1
 Breakpoint 1, 0x00000000004005ce in vuln ()
 (gdb)
 
-"Breakpoint 1, 0x00000000004005ce in vuln ()" means that the first break point we have set, was established at address "0x00000000004005c", which is the same address as "0x4005c"; An address is a number in this case, so zeros at the left cause no effect. Note that in other cases, zeros at the left can have an effect if what we are reading is not being interpreted as a number.
+"Breakpoint 1, 0x00000000004005ce in vuln ()" means that the first break point we have set, was established at address "0x00000000004005ce", which is the same address as "0x4005ce"; An address is a number in this case, so zeros at the left cause no effect. Note that in other cases, zeros at the left can have an effect if what we are reading is not being interpreted as a number.
 
 ===== Processor registers
 


### PR DESCRIPTION
Fixes address value typo in the following section:
9. Binary Exploitation
9.4. Example of Execution of a program
9.4.1. GDB, Assembly and machine code