### PR TITLE
fix typos in print statements

### DIFF
--- a/chapters/c.adoc
+++ b/chapters/c.adoc
@@ -404,14 +404,14 @@ int main() {
     printf("\n This is arr[0]: %c ", arr[0]);
     printf("\n This is *arr: %c ", *(arr+0));
     //as well as:
-    printf("\n This is arr[0]: %c ", arr[1]);
-    printf("\n This is *(arr+0): %c ", *(arr+1));
-    printf("\n This is arr[1]: %c ", arr[2]);
-    printf("\n This is *(arr+1): %c ", *(arr+2));
-    printf("\n This is arr[2]: %c ", arr[3]);
-    printf("\n This is *(arr+2): %c ", *(arr+3));
-    printf("\n This is arr[3]: %c ", arr[4]);
-    printf("\n This is *(arr+3): %c ", *(arr+4));
+    printf("\n This is arr[1]: %c ", arr[1]);
+    printf("\n This is *(arr+1): %c ", *(arr+1));
+    printf("\n This is arr[2]: %c ", arr[2]);
+    printf("\n This is *(arr+2): %c ", *(arr+2));
+    printf("\n This is arr[3]: %c ", arr[3]);
+    printf("\n This is *(arr+3): %c ", *(arr+3));
+    printf("\n This is arr[4]: %c ", arr[4]);
+    printf("\n This is *(arr+4): %c ", *(arr+4));
     //understanding that, you can see now why in C, a thing that looks very weird as the following, makes sense:
     printf("\n This is 1[arr]: %c ", 1[arr]);
     //As you see, it printed 'e', because that expression is just *(1+a), which is the same as *(a+1)


### PR DESCRIPTION
## What?
This PR fixes typos in chapter "9.4. C Pointers".

There is a mismatch between the expressions that the `printf` statements claim to show and the expressions they are actually showing.

## Render
```sh
$ make
asciidoctor -a toc=left book.adoc
asciidoctor: WARNING: optional gem 'pygments.rb' is not available (reason: cannot load 'pygments'). Functionality disabled.
```

I don't have Ruby installed so no syntax highlighting.
![Screenshot from 2024-07-13 15-47-02](https://github.com/user-attachments/assets/f65c784b-5927-4f86-8b0a-180a0ba580f8)
